### PR TITLE
Add functionality for calling upcoming releases page

### DIFF
--- a/albumoftheyearapi/album.py
+++ b/albumoftheyearapi/album.py
@@ -1,0 +1,122 @@
+import json
+from urllib.request import Request, urlopen
+from bs4 import BeautifulSoup
+
+class Album:
+    def __init__(self, name, artist, date):
+        self.name = name
+        self.artist = artist
+        self.release_date = date
+
+    def to_JSON(self):
+        return json.dumps(
+            self,
+            default=lambda o: o.__dict__,
+            sort_keys=True,
+            indent=0)
+
+class AlbumMethods:
+    def __init__(self):
+        self.upcoming_album_class = 'albumBlock five small'
+        self.aoty_albums_per_page = 60
+        self.page_limit = 21
+
+    def upcoming_releases_by_limit(self, total):
+        min_page_number = 1
+        max_page_number = total // self.aoty_albums_per_page
+        if total % self.aoty_albums_per_page != 0:
+            max_page_number += 1
+        upcoming_albums = {}
+        albums = []
+        counter = total
+        for page_number in range(min_page_number, max_page_number+1):
+            try:
+                if counter < self.aoty_albums_per_page:
+                    albums += self._get_upcoming_releases_by_page(page_number)[:counter]
+                else:
+                    albums += self._get_upcoming_releases_by_page(page_number)
+                    counter -= self.aoty_albums_per_page
+            except Exception as e:
+                return json.dumps(
+                    self._build_error_response('Page Limit Error',
+                                               'Number of albums exceeded page limit. Exception raise: .' + e))
+        json_albums = [album.to_JSON() for album in albums]
+        upcoming_albums['albums'] = json_albums
+        return json.dumps(upcoming_albums)
+
+    def upcoming_releases_by_page(self, page_number):
+        upcoming_albums = {}
+        try:
+            parsed_albums = self._get_upcoming_releases_by_page(page_number)
+        except:
+            return json.dumps(self._build_error_response('Page Limit Error', 'The page number requested is out of range.'))
+        json_albums = [album.to_JSON() for album in parsed_albums]
+        upcoming_albums['albums'] = json_albums
+        return json.dumps(upcoming_albums)
+
+    def upcoming_releases_by_date(self, month, day):
+        upcoming_albums = {}
+        try:
+            parsed_albums = self._get_upcoming_releases_by_date(month, day)
+        except Exception as e:
+            return json.dumps(self._build_error_response('Releases by date Error: ', e.message))
+        json_albums = [album.to_JSON() for album in parsed_albums]
+        upcoming_albums['albums'] = json_albums
+        return json.dumps(upcoming_albums)
+
+    def _get_upcoming_releases_by_date(self, month, day):
+        month_name = self._map_month_number_to_name(month)
+        target_date = (month_name + ' ' + str(day)).strip()
+        next_date = (month_name + ' ' + str(day+1)).strip()
+        page_number = 1
+        result_albums = []
+
+        complete = False
+        while not complete:
+            albums = self._get_upcoming_releases_by_page(page_number)
+            for album in albums:
+                if album.release_date == target_date:
+                    result_albums.append(album)
+
+                if album.release_date == next_date:
+                    complete = True
+            page_number += 1
+        return result_albums
+
+
+    def _build_error_response(self, error_type, msg):
+        error_dict = {'error': error_type, 'message': msg}
+        return error_dict
+
+    def _map_month_number_to_name(self, month_number):
+        month_names = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun','Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+        try:
+            return month_names[month_number-1]
+        except:
+            raise Exception('Invalid month number')
+
+    def _get_upcoming_releases_by_page(self, page_number):
+        if page_number > self.page_limit:
+            raise Exception('Page number out of range')
+        if int(page_number) == 1:
+            page_number = ''
+        url = 'https://www.albumoftheyear.org/upcoming/' + str(page_number) + '/'
+        page = self._get_release_page_from_request(url)
+        albums = page.find_all("div", {"class": self.upcoming_album_class})
+        parsed_albums = self._parse_albums(albums)
+        return parsed_albums
+
+    def _get_release_page_from_request(self, url):
+        request = Request(url, headers={"User-Agent": "Mozilla/6.0"})
+        unparsed_page = urlopen(request).read()
+        release_page = BeautifulSoup(unparsed_page, "html.parser")
+        return release_page
+
+    def _parse_albums(self, unparsed_albums):
+        parsed_albums = []
+        for album in unparsed_albums:
+            artist = str(album.find("div", {"class": "artistTitle"}).getText())
+            title = str(album.find("div", {"class": "albumTitle"}).getText())
+            date = str(album.find("div", {"class": "type"}).getText())
+            parsed_albums.append(Album(title, artist, date))
+        return parsed_albums

--- a/albumoftheyearapi/client.py
+++ b/albumoftheyearapi/client.py
@@ -2,9 +2,10 @@
 
 from albumoftheyearapi.user import UserMethods
 from albumoftheyearapi.artist import ArtistMethods
+from albumoftheyearapi.album import AlbumMethods
 
 
-class AOTY(UserMethods, ArtistMethods):
+class AOTY(UserMethods, ArtistMethods, AlbumMethods):
     """A light weight python library that acts as an API for https://www.albumoftheyear.org"""
 
     def __init__(self):
@@ -16,3 +17,6 @@ class AOTY(UserMethods, ArtistMethods):
         self.url = ""
         self.user_url = "https://www.albumoftheyear.org/user/"
         self.artist_url = "https://www.albumoftheyear.org/artist/"
+        self.upcoming_album_class = 'albumBlock five small'
+        self.aoty_albums_per_page = 60
+        self.page_limit = 21

--- a/test_album.py
+++ b/test_album.py
@@ -1,0 +1,30 @@
+from sqlalchemy import null
+from albumoftheyearapi import AOTY
+import pytest, json, datetime
+
+@pytest.mark.first
+def test_initialize():
+    c = AOTY()
+    pytest.client = c
+    assert pytest.client != null
+
+def test_upcoming_albums_limit():
+    albums_json = pytest.client.upcoming_releases_by_limit(62)
+    albums = json.loads(albums_json)
+    assert (len(albums['albums'])) == 62
+
+def test_upcoming_albums_page():
+    albums_json = pytest.client.upcoming_releases_by_page(3)
+    albums = json.loads(albums_json)
+    assert (len(albums['albums'])) == 60
+
+def test_upcoming_albums_date():
+    tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+    tomorrow_month = tomorrow.month
+    tomorrow_day = tomorrow.day
+    albums_json = pytest.client.upcoming_releases_by_date(tomorrow_month, tomorrow_day)
+    albums = json.loads(albums_json)
+    assert len(albums['albums']) < 60
+
+if __name__ == "__main__":
+    pytest.main


### PR DESCRIPTION
Adding new scraping endpoint to pull album data from the upcoming releases page.

# Changes

## Added AlbumMethods class 

Class contains methods for scraping pages from the upcoming releases section of AOTY.
https://www.albumoftheyear.org/upcoming/

Pagination is supported. There is a method for scraping based on page number. This is also used for pagination, and other methods support scraping based on release date and user set number of albums (i.e. fetch me X number of upcoming releases)

There is also an error method for sending back exception messages.

All responses are returned in JSON format. Successful responses are in the form of a JSON object with 'albums' key, value being a list of album objects.

## Added Album Class


Module also contains Album class for encapsulating album data. This is an object with the album title, artist and release date, all in string format. The class also has a method for JSON serialisation.

## Added tests for album Methods

Added pytest unit tests for album methods. These are testing getting albums by page number, limit and date. All test whether an expected number of albums are returned, since the data will be dynamic.
The assumption made is that there will not be more than 60 albums released on one day.

## Updates to Client class

Class attributes have been added to the client class so they can be used.



